### PR TITLE
feat: upgrade logger

### DIFF
--- a/pkg/baphomet/go.mod
+++ b/pkg/baphomet/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/antonioiubatti93/abraxas/logger v0.0.0-20211104104435-ec0c4c475dcd
-	github.com/antonioiubatti93/baphomet v0.3.0
+	github.com/antonioiubatti93/baphomet/logger v0.0.0-20211104110036-55ade6439d8a
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.0
 )

--- a/pkg/baphomet/go.sum
+++ b/pkg/baphomet/go.sum
@@ -1,7 +1,7 @@
 github.com/antonioiubatti93/abraxas/logger v0.0.0-20211104104435-ec0c4c475dcd h1:pZZGKY3xCRewETbPG1EST/2mysOVz4wzSAUTesw4+fc=
 github.com/antonioiubatti93/abraxas/logger v0.0.0-20211104104435-ec0c4c475dcd/go.mod h1:v/ffGfeb92RxlET/33RRC5THEnckkLEl9awe7sAKXg0=
-github.com/antonioiubatti93/baphomet v0.3.0 h1:gn5BUwqxFAf8viPKUCzEcL5YuuzKxf9KAnXgejYTq84=
-github.com/antonioiubatti93/baphomet v0.3.0/go.mod h1:iwMMmVtNotZaSppVD11e6SATtfF8oPEGbhPIYuhSICI=
+github.com/antonioiubatti93/baphomet/logger v0.0.0-20211104110036-55ade6439d8a h1:Zvg7xwA2Xoa2gQo1C4T9BwJB3mI9i1sYS0+CdhFt8LI=
+github.com/antonioiubatti93/baphomet/logger v0.0.0-20211104110036-55ade6439d8a/go.mod h1:8w1xvB37B23ucxLwTM4s0W15kg879jAABcqAKtzc1QI=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
Necessary:
```bash
go clean -modcache
```
Otherwise one bumps into [`go module found, but does not contain package`](https://stackoverflow.com/questions/62974985/go-module-latest-found-but-does-not-contain-package) issue.